### PR TITLE
fix: convert byte to uint8

### DIFF
--- a/src/android/CordovaPluginMifareUltralight.java
+++ b/src/android/CordovaPluginMifareUltralight.java
@@ -257,7 +257,7 @@ public class CordovaPluginMifareUltralight extends CordovaPlugin {
     static JSONArray byteArrayToJSON(byte[] bytes) {
         JSONArray json = new JSONArray();
         for (byte aByte : bytes) {
-            json.put(aByte);
+            json.put(aByte & 0xFF);
         }
         return json;
     }


### PR DESCRIPTION
Convert byte to uint8 by masking with 0xFF (as seen in CordovaPluginMifareUltralight.java:362).

Fix #2.